### PR TITLE
Changed to v0.0.3 for pypi packaging version operation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         'pytest-cov==2.5.1',
         'timeout-decorator==0.4.0',
     ],
-    version='0.0.2a',
+    version='0.0.3',
     description='FaradayRF TUN/TAP adapter',
     author='FaradayRF',
     author_email='Support@FaradayRF.com',


### PR DESCRIPTION
Pypi doesn't like v0.0.2a and thinks it's older than v0.0.2 so I need to
move to v0.0.3