### PR TITLE
Update scapy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ pytest==3.4.1
 pytest-cov==2.5.1
 python-pytun==2.2.1
 requests==2.18.4
-scapy-python3==0.23
+scapy>=2.4.0
 six==1.11.0
 sliplib==0.3.0
 sphinx-rtd-theme==0.2.4

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         'pytest-cov==2.5.1',
         'python-pytun==2.2.1',
         'requests==2.18.4',
-        'scapy-python3==0.23',
+        'scapy>=2.4.0',
         'six==1.11.0',
         'sliplib==0.3.0',
         'sphinx-rtd-theme==0.2.4',


### PR DESCRIPTION
scapy-python3 is an unofficial fork that is getting very oudated (many bug fixes missing).
Migrates to original and up-to-date scapy, which now supports both python 2 and 3